### PR TITLE
refactor(handler): hide internal error details from clients

### DIFF
--- a/internal/interface/grpc/exercise/handler.go
+++ b/internal/interface/grpc/exercise/handler.go
@@ -2,6 +2,7 @@ package exercise
 
 import (
 	"context"
+	"log"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -37,7 +38,8 @@ func (h *ExerciseHandler) ListExercises(ctx context.Context, req *exercisev1.Lis
 		if _, ok := status.FromError(err); ok {
 			return nil, err
 		}
-		return nil, status.Error(codes.Internal, err.Error())
+		log.Printf("ListExercises: internal error: %v", err)
+		return nil, status.Error(codes.Internal, "internal error")
 	}
 
 	responses := make([]*exercisev1.Exercise, 0, len(exercises))

--- a/internal/interface/grpc/muscle/handler.go
+++ b/internal/interface/grpc/muscle/handler.go
@@ -2,6 +2,7 @@ package muscle
 
 import (
 	"context"
+	"log"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -37,7 +38,8 @@ func (h *MuscleHandler) ListMuscles(ctx context.Context, req *musclev1.ListMuscl
 		if _, ok := status.FromError(err); ok {
 			return nil, err
 		}
-		return nil, status.Error(codes.Internal, err.Error())
+		log.Printf("ListMuscles: internal error: %v", err)
+		return nil, status.Error(codes.Internal, "internal error")
 	}
 
 	responses := make([]*musclev1.Muscle, 0, len(muscles))

--- a/internal/interface/grpc/set/handler.go
+++ b/internal/interface/grpc/set/handler.go
@@ -3,6 +3,7 @@ package set
 import (
 	"context"
 	"errors"
+	"log"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -47,7 +48,8 @@ func (h *SetHandler) CreateSet(ctx context.Context, req *setv1.CreateSetRequest)
 		if errors.Is(err, exercise.ErrExerciseNotFound) {
 			return nil, status.Error(codes.NotFound, err.Error())
 		}
-		return nil, status.Error(codes.Internal, err.Error())
+		log.Printf("CreateSet: internal error: %v", err)
+		return nil, status.Error(codes.Internal, "internal error")
 	}
 
 	return &setv1.CreateSetResponse{
@@ -61,7 +63,8 @@ func (h *SetHandler) ListSets(ctx context.Context, req *setv1.ListSetsRequest) (
 		if _, ok := status.FromError(err); ok {
 			return nil, err
 		}
-		return nil, status.Error(codes.Internal, err.Error())
+		log.Printf("ListSets: internal error: %v", err)
+		return nil, status.Error(codes.Internal, "internal error")
 	}
 
 	responses := make([]*setv1.Set, 0, len(sets))


### PR DESCRIPTION
Follow-up to #20.

## Summary
Reviewers raised the concern that returning `err.Error()` for `codes.Internal` leaks implementation details (DB column names, dependency error strings, internal paths) to clients. This PR hardens the Internal branch in every handler:

- Replace `status.Error(codes.Internal, err.Error())` with a fixed `"internal error"` message.
- Log the underlying error server-side via `log.Printf("Method: internal error: %v", err)` so operators can still debug.
- Other status codes (`InvalidArgument`, `NotFound`, `Unauthenticated`, `PermissionDenied`) keep their original messages because they are client-actionable (the message tells the caller how to fix their request).

A `UnaryServerInterceptor` would centralize this logging better; that is left as a follow-up.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (handler packages still at 100% statement coverage; assertions are on `status.Code(err)`, message changes are not observed by tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)